### PR TITLE
add initial support for non-scalar map/set/stack values

### DIFF
--- a/src/java/boa/compiler/visitors/CodeGeneratingVisitor.java
+++ b/src/java/boa/compiler/visitors/CodeGeneratingVisitor.java
@@ -1316,10 +1316,8 @@ public class CodeGeneratingVisitor extends AbstractCodeGeneratingVisitor {
 				return;
 			}
 
-			// FIXME rdyer if the type is a type identifier, n.getType() returns Identifier
-			// and maps/stacks/sets wind up not having the proper constructors here
 			n.getType().accept(this);
-			st.add("rhs", code.removeLast());
+			st.add("rhs", "new " + code.removeLast() + "()");
 			code.add(st.render());
 			return;
 		}
@@ -1627,7 +1625,12 @@ public class CodeGeneratingVisitor extends AbstractCodeGeneratingVisitor {
 	public void visit(final ArrayType n) {
 		final ST st = stg.getInstanceOf("ArrayType");
 
+		// arrays dont need their component type boxed
+		boolean boxing = n.env.getNeedsBoxing();
+		n.env.setNeedsBoxing(false);
 		n.getValue().accept(this);
+		n.env.setNeedsBoxing(boxing);
+
 		st.add("type", code.removeLast());
 
 		code.add(st.render());

--- a/templates/BoaJava.stg
+++ b/templates/BoaJava.stg
@@ -16,10 +16,10 @@ identifierMap ::= [
 ]
 		
 VarDecl(isstatic, type, id) ::= "<if(isstatic)>static <endif><type> ___<id>;<\n>"
-ArrayType(type) ::= "new <type>[]"
-MapType(key, value) ::= "new java.util.HashMap\<<key>, <value>>()"
-StackType(value) ::= "new java.util.Stack\<<value>>()"
-SetType(value) ::= "new java.util.HashSet\<<value>>()"
+ArrayType(type) ::= "<type>[]"
+MapType(key, value) ::= "java.util.HashMap\<<key>, <value>>"
+StackType(value) ::= "java.util.Stack\<<value>>"
+SetType(value) ::= "java.util.HashSet\<<value>>"
 Block(statements) ::= <<
 {
 	<statements:{s | <s>}>}

--- a/test/codegen/nested-maps.boa
+++ b/test/codegen/nested-maps.boa
@@ -1,0 +1,27 @@
+o: output sum of int;
+o << 1;
+
+type stackType = stack of int;
+type mapType = map[string] of int;
+
+m: mapType;
+a: array of int;
+
+sa: stack of array of int;
+push(sa, a);
+
+s: stack of mapType;
+push(s, m);
+
+ms: map[string] of stackType;
+intS: stackType;
+ms["foo"] = intS;
+
+s2: set of stackType;
+add(s2, intS);
+
+m2: map[string] of mapType;
+m2["foo"] = m;
+
+m3: map[string] of map[string] of mapType;
+m3["foo"] = m2;


### PR DESCRIPTION
The instantiation of these types is now directly in the codegen class, and not part of any template.  It seemed a bit overkill to make a template just for 'new'.