### PR TITLE
Change in MeanAggregator.jaav to fix FloatMeanAggreagator small bug

### DIFF
--- a/src/java/boa/aggregators/MeanAggregator.java
+++ b/src/java/boa/aggregators/MeanAggregator.java
@@ -28,9 +28,17 @@ abstract class MeanAggregator extends Aggregator {
 
 	public void count(final String metadata) {
 		if (metadata == null)
+		{
 			this.count++;
+		}			
 		else
-			this.count += Long.parseLong(metadata);
+		{
+			try {
+				this.count += Long.parseLong(metadata);
+			} catch (NumberFormatException e) {
+				this.count += (long)Double.parseDouble(metadata);
+			}
+		}
 	}
 
 	/** {@inheritDoc} */


### PR DESCRIPTION
# Problem
When I was trying to use a mean aggregator `output mean[string][float][float][int] of float;` I was getting the error.

> java.lang.RuntimeException: java.lang.NumberFormatException: For input string: "1.0"
> 	at boa.runtime.BoaReducer.reduce(BoaReducer.java:106)
> 	at boa.runtime.BoaReducer.reduce(BoaReducer.java:1)
> 	at org.apache.hadoop.mapreduce.Reducer.run(Reducer.java:176)
> 	at org.apache.hadoop.mapred.ReduceTask.runNewReducer(ReduceTask.java:649)
> 	at org.apache.hadoop.mapred.ReduceTask.run(ReduceTask.java:417)
> 	at org.apache.hadoop.mapred.LocalJobRunner$Job.run(LocalJobRunner.java:260)
> Caused by: java.lang.NumberFormatException: For input string: "1.0"
> 	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
> 	at java.lang.Long.parseLong(Long.java:589)
> 	at java.lang.Long.parseLong(Long.java:631)
> 	at boa.aggregators.MeanAggregator.count(MeanAggregator.java:38)
> 	at boa.aggregators.FloatMeanAggregator.aggregate(FloatMeanAggregator.java:58)
> 	at boa.aggregators.FloatMeanAggregator.aggregate(FloatMeanAggregator.java:44)
> 	at boa.runtime.BoaReducer.reduce(BoaReducer.java:100)
> 	... 5 more

# Fix
To fix this error i modified the MeanAggregator.java file