### PR TITLE
fixes #163 - add support for """multiline string literals"""

### DIFF
--- a/src/antlr/Boa.g
+++ b/src/antlr/Boa.g
@@ -653,7 +653,8 @@ stringLiteral returns [StringLiteral ast]
 	locals [int l, int c]
 	@init { $l = getStartLine(); $c = getStartColumn(); }
 	@after { $ast.setPositions($l, $c, getEndLine(), getEndColumn()); }
-	: lit=StringLiteral { $ast = new StringLiteral(false, $lit.text); }
+	: lit=MultilineStringLiteral { $ast = new StringLiteral(false, $lit.text.substring(2, $lit.text.length() - 2).replaceAll("\n", "\\\\n")); }
+	| lit=StringLiteral { $ast = new StringLiteral(false, $lit.text); }
 	| lit=RegexLiteral  { $ast = new StringLiteral(true, $lit.text); }
 	;
 
@@ -831,6 +832,10 @@ RegexLiteral
 fragment
 RegexCharacter
 	: ~[`\n\r]
+	;
+
+MultilineStringLiteral
+	: '"""' (StringCharacter | [\n\r])* '"""'
 	;
 
 StringLiteral

--- a/src/antlr/Boa.g
+++ b/src/antlr/Boa.g
@@ -653,7 +653,7 @@ stringLiteral returns [StringLiteral ast]
 	locals [int l, int c]
 	@init { $l = getStartLine(); $c = getStartColumn(); }
 	@after { $ast.setPositions($l, $c, getEndLine(), getEndColumn()); }
-	: lit=MultilineStringLiteral { $ast = new StringLiteral(false, $lit.text.substring(2, $lit.text.length() - 2).replaceAll("\n", "\\\\n")); }
+	: lit=MultilineStringLiteral { $ast = new StringLiteral(false, "\"" + $lit.text.substring(3, $lit.text.length() - 3).replaceAll("\"", "\\\\\"").replaceAll("\n", "\\\\n") + "\""); }
 	| lit=StringLiteral { $ast = new StringLiteral(false, $lit.text); }
 	| lit=RegexLiteral  { $ast = new StringLiteral(true, $lit.text); }
 	;
@@ -761,6 +761,7 @@ DOLLAR      : '$';
 EQUALS      : '=';
 EMIT        : '<<';
 RIGHT_ARROW : '->';
+ML_STRING   : '"""';
 
 //
 // literals
@@ -835,7 +836,7 @@ RegexCharacter
 	;
 
 MultilineStringLiteral
-	: '"""' (StringCharacter | [\n\r])* '"""'
+	: ML_STRING (StringCharacter | ["\n\r])*? ML_STRING
 	;
 
 StringLiteral

--- a/src/antlr/BoaNoActions.g
+++ b/src/antlr/BoaNoActions.g
@@ -387,7 +387,8 @@ characterLiteral
 	;
 
 stringLiteral
-	: StringLiteral
+	: MultilineStringLiteral
+	| StringLiteral
 	| RegexLiteral
 	;
 
@@ -562,6 +563,10 @@ RegexLiteral
 fragment
 RegexCharacter
 	: ~[`\n\r]
+	;
+
+MultilineStringLiteral
+	: '"""' (StringCharacter | [\n\r])* '"""'
 	;
 
 StringLiteral

--- a/src/antlr/BoaNoActions.g
+++ b/src/antlr/BoaNoActions.g
@@ -492,6 +492,7 @@ DOLLAR      : '$';
 EQUALS      : '=';
 EMIT        : '<<';
 RIGHT_ARROW : '->';
+ML_STRING   : '"""';
 
 //
 // literals
@@ -566,7 +567,7 @@ RegexCharacter
 	;
 
 MultilineStringLiteral
-	: '"""' (StringCharacter | [\n\r])* '"""'
+	: ML_STRING (StringCharacter | ["\n\r])*? ML_STRING
 	;
 
 StringLiteral

--- a/src/test/boa/test/compiler/TestParserBad.java
+++ b/src/test/boa/test/compiler/TestParserBad.java
@@ -53,11 +53,11 @@ public class TestParserBad extends BaseTest {
 	public void badIdentifiers() throws IOException {
 		parse(load(badDir + "bad-identifiers.boa"),
 			new String[] {
-				"2,0: extraneous input '_' expecting {'of', 'if', 'do', 'map', 'stack', 'set', 'for', 'foreach', 'ifall', 'exists', 'not', 'type', 'else', 'case', 'output', 'format', 'while', 'break', 'array', 'static', 'switch', 'return', 'weight', 'default', 'continue', 'function', 'fixp', 'visitor', 'traversal', 'before', 'after', 'stop', ';', '{', '(', '+', '-', '~', '!', '$', IntegerLiteral, FloatingPointLiteral, CharacterLiteral, RegexLiteral, StringLiteral, TimeLiteral, Identifier}",
+				"2,0: extraneous input '_' expecting {'of', 'if', 'do', 'map', 'stack', 'set', 'for', 'foreach', 'ifall', 'exists', 'not', 'type', 'else', 'case', 'output', 'format', 'while', 'break', 'array', 'static', 'switch', 'return', 'weight', 'default', 'continue', 'function', 'fixp', 'visitor', 'traversal', 'before', 'after', 'stop', ';', '{', '(', '+', '-', '~', '!', '$', IntegerLiteral, FloatingPointLiteral, CharacterLiteral, RegexLiteral, MultilineStringLiteral, StringLiteral, TimeLiteral, Identifier}",
 				"3,1: error: ';' expected",
 				"4,9: no viable alternative at input '+id:'",
 				"4,5: error: ';' expected",
-				"4,9: mismatched input ':' expecting {<EOF>, 'of', 'if', 'do', 'map', 'stack', 'set', 'for', 'foreach', 'ifall', 'exists', 'not', 'type', 'else', 'case', 'output', 'format', 'while', 'break', 'array', 'static', 'switch', 'return', 'weight', 'default', 'continue', 'function', 'fixp', 'visitor', 'traversal', 'before', 'after', 'stop', ';', '.', '{', '(', '[', 'or', '|', '||', 'and', '&', '&&', '+', '-', '^', '*', '/', '%', '>>', '~', '!', '$', '<<', IntegerLiteral, FloatingPointLiteral, CharacterLiteral, RegexLiteral, StringLiteral, TimeLiteral, Identifier}",
+				"4,9: mismatched input ':' expecting {<EOF>, 'of', 'if', 'do', 'map', 'stack', 'set', 'for', 'foreach', 'ifall', 'exists', 'not', 'type', 'else', 'case', 'output', 'format', 'while', 'break', 'array', 'static', 'switch', 'return', 'weight', 'default', 'continue', 'function', 'fixp', 'visitor', 'traversal', 'before', 'after', 'stop', ';', '.', '{', '(', '[', 'or', '|', '||', 'and', '&', '&&', '+', '-', '^', '*', '/', '%', '>>', '~', '!', '$', '<<', IntegerLiteral, FloatingPointLiteral, CharacterLiteral, RegexLiteral, MultilineStringLiteral, StringLiteral, TimeLiteral, Identifier}",
 				"4,12: error: ';' expected"
 			});
 	}
@@ -71,7 +71,7 @@ public class TestParserBad extends BaseTest {
 	@Test
 	public void assignToMap() throws IOException {
 		parse(load(badDir + "assign-to-map.boa"),
-			new String[] { "2,9: extraneous input ':' expecting {<EOF>, 'of', 'if', 'do', 'map', 'stack', 'set', 'for', 'foreach', 'ifall', 'exists', 'not', 'type', 'else', 'case', 'output', 'format', 'while', 'break', 'array', 'static', 'switch', 'return', 'weight', 'default', 'continue', 'function', 'fixp', 'visitor', 'traversal', 'before', 'after', 'stop', ';', '.', '{', '(', '[', 'or', '|', '||', 'and', '&', '&&', '+', '-', '^', '*', '/', '%', '>>', '~', '!', '$', '<<', IntegerLiteral, FloatingPointLiteral, CharacterLiteral, RegexLiteral, StringLiteral, TimeLiteral, Identifier}",
+			new String[] { "2,9: extraneous input ':' expecting {<EOF>, 'of', 'if', 'do', 'map', 'stack', 'set', 'for', 'foreach', 'ifall', 'exists', 'not', 'type', 'else', 'case', 'output', 'format', 'while', 'break', 'array', 'static', 'switch', 'return', 'weight', 'default', 'continue', 'function', 'fixp', 'visitor', 'traversal', 'before', 'after', 'stop', ';', '.', '{', '(', '[', 'or', '|', '||', 'and', '&', '&&', '+', '-', '^', '*', '/', '%', '>>', '~', '!', '$', '<<', IntegerLiteral, FloatingPointLiteral, CharacterLiteral, RegexLiteral, MultilineStringLiteral, StringLiteral, TimeLiteral, Identifier}",
 				"2,12: error: ';' expected"
 			});
 	}

--- a/test/parsing/multiline-strings.boa
+++ b/test/parsing/multiline-strings.boa
@@ -1,15 +1,25 @@
 o: output sum of int;
 o << 1;
 
-s := """This is
+s1 := """This is
 a multi-line
 string""";
+
+s2 := """This is a single line 'multiline' string.""";
+s3 := """This is a single line "multiline" string.""";
+
+s4 := """This is a
+multi line
+'multiline' string.""";
+s5 := """This is a
+multi line
+"multiline"" string.""";
 
 f := function(s: string) : string {
     return s + """a multi-line
 string""";
 };
 
-s2 := f("""passing
+s6 := f("""passing
 multi-line
-string""");
+"string" to function""");


### PR DESCRIPTION
Support the Python-styled triple double-quote multiline string literals in Boa suggested in #163.