### PR TITLE
fix issues writing and combining sequence files

### DIFF
--- a/src/java/boa/datagen/SeqCombiner.java
+++ b/src/java/boa/datagen/SeqCombiner.java
@@ -99,7 +99,9 @@ public class SeqCombiner {
 						if (crb.getRevisionsCount() > 0) {
 							for (Revision.Builder rb : crb.getRevisionsBuilderList()) {
 								for (ChangedFile.Builder cfb : rb.getFilesBuilderList()) {
-									cfb.setKey(lastAstWriterKey + cfb.getKey());
+									long key = cfb.getKey();
+									if (key > 0)
+										cfb.setKey(lastAstWriterKey + key);
 								}
 							}
 						} else {
@@ -116,8 +118,8 @@ public class SeqCombiner {
 			} finally {
 				r.close();
 			}
-			lastAstWriterKey = readAndAppend(conf, fileSystem, astWriter, base + "/ast/" + name, lastAstWriterKey);
-			lastCommitWriterKey = readAndAppend(conf, fileSystem, commitWriter, base + "/commit/" + name, lastCommitWriterKey);
+			lastCommitWriterKey = readAndAppendCommit(conf, fileSystem, commitWriter, base + "/commit/" + name, lastAstWriterKey, lastCommitWriterKey);
+			lastAstWriterKey = readAndAppendAst(conf, fileSystem, astWriter, base + "/ast/" + name, lastAstWriterKey);
 		}
 		projectWriter.close();
 		astWriter.close();
@@ -126,7 +128,33 @@ public class SeqCombiner {
 		fileSystem.close();
 	}
 
-	public static long readAndAppend(Configuration conf, FileSystem fileSystem, MapFile.Writer astWriter, String fileName, long lastKey) throws IOException {
+	public static long readAndAppendCommit(Configuration conf, FileSystem fileSystem, MapFile.Writer astWriter, String fileName, long lastAstKey, long lastCommitKey) throws IOException {
+		long newLastKey = lastCommitKey;
+		SequenceFile.Reader r = new SequenceFile.Reader(fileSystem, new Path(fileName), conf);
+		LongWritable longKey = new LongWritable();
+		BytesWritable value = new BytesWritable();
+		try {
+			while (r.next(longKey, value)) {
+				newLastKey = longKey.get() + lastCommitKey;
+				Revision rev = Revision.parseFrom(CodedInputStream.newInstance(value.getBytes(), 0, value.getLength()));
+				Revision.Builder rb = Revision.newBuilder(rev);
+				for (ChangedFile.Builder cfb : rb.getFilesBuilderList()) {
+					long key = cfb.getKey();
+					if (key > 0)
+						cfb.setKey(lastAstKey + key);
+				}
+				astWriter.append(new LongWritable(newLastKey), new BytesWritable(rb.build().toByteArray()));
+			}
+		} catch (Exception e) {
+			System.err.println(fileName);
+			e.printStackTrace();
+		} finally {
+			r.close();
+		}
+		return newLastKey;
+	}
+
+	public static long readAndAppendAst(Configuration conf, FileSystem fileSystem, MapFile.Writer astWriter, String fileName, long lastKey) throws IOException {
 		long newLastKey = lastKey;
 		SequenceFile.Reader r = new SequenceFile.Reader(fileSystem, new Path(fileName), conf);
 		LongWritable longKey = new LongWritable();

--- a/src/java/boa/datagen/SeqRepoImporter.java
+++ b/src/java/boa/datagen/SeqRepoImporter.java
@@ -158,7 +158,7 @@ public class SeqRepoImporter {
 		private int counter = 0;
 		private String suffix;
 		private SequenceFile.Writer projectWriter, astWriter, commitWriter, contentWriter;
-		private long astWriterLen = 0, commitWriterLen = 0, contentWriterLen = 0;
+		private long astWriterLen = 1, commitWriterLen = 1, contentWriterLen = 1;
 
 		public ImportTask(int id) throws IOException {
 			this.id = id;

--- a/src/java/boa/datagen/scm/AbstractCommit.java
+++ b/src/java/boa/datagen/scm/AbstractCommit.java
@@ -48,8 +48,6 @@ import boa.types.Shared.ChangeKind;
 import boa.types.Shared.Person;
 import boa.datagen.DefaultProperties;
 import boa.datagen.dependencies.PomFile;
-import boa.datagen.treed.TreedConstants;
-import boa.datagen.treed.TreedMapper;
 import boa.datagen.util.CssVisitor;
 import boa.datagen.util.FileIO;
 import boa.datagen.util.HtmlVisitor;
@@ -60,7 +58,6 @@ import boa.datagen.util.PHPErrorCheckVisitor;
 import boa.datagen.util.PHPVisitor;
 import boa.datagen.util.Properties;
 import boa.datagen.util.XMLVisitor;
-import boa.datagen.util.JavaASTUtil;
 import boa.datagen.util.JavaErrorCheckVisitor;
 
 /**
@@ -89,7 +86,7 @@ public abstract class AbstractCommit {
 			cfb = ChangedFile.newBuilder();
 			cfb.setName(path);
 			cfb.setKind(FileKind.OTHER);
-			cfb.setKey(-1);
+			cfb.setKey(0);
 			cfb.setAst(false);
 			fileNameIndices.put(path, changedFiles.size());
 			changedFiles.add(cfb);
@@ -187,7 +184,7 @@ public abstract class AbstractCommit {
 		for (ChangedFile.Builder cfb : changedFiles) {
 			cfb.setKind(FileKind.OTHER);
 			if (cfb.getChange() == ChangeKind.DELETED || cfb.getChange() == ChangeKind.UNKNOWN) {
-				cfb.setKey(-1);
+				cfb.setKey(0);
 //				cfb.setKind(connector.revisions.get(cfb.getPreviousVersions(0)).changedFiles.get(cfb.getPreviousIndices(0)).getKind());
 			} else
 				processChangeFile(cfb, parse);

--- a/src/java/boa/datagen/scm/AbstractConnector.java
+++ b/src/java/boa/datagen/scm/AbstractConnector.java
@@ -66,7 +66,7 @@ public abstract class AbstractConnector implements AutoCloseable {
 	protected String projectName;
 	protected int headCommitOffset = -1;
 	protected SequenceFile.Writer astWriter, contentWriter;
-	protected long astWriterLen = 0, contentWriterLen = 0;
+	protected long astWriterLen = 1, contentWriterLen = 1;
 
 	public long getAstWriterLen() {
 		return astWriterLen;
@@ -160,7 +160,7 @@ public abstract class AbstractConnector implements AutoCloseable {
 				}
 				ChangedFile.Builder fb = ChangedFile.newBuilder(cf);
 				fb.setAst(false);
-				fb.setKey(-1);
+				fb.setKey(0);
 				
 				long len = -1;
 				if (astWriter != null) {

--- a/src/java/boa/datagen/scm/GitCommit.java
+++ b/src/java/boa/datagen/scm/GitCommit.java
@@ -191,7 +191,7 @@ public class GitCommit extends AbstractCommit {
 						cfb.setChange(ChangeKind.ADDED);
 						cfb.setName(path);
 						cfb.setKind(FileKind.OTHER);
-						cfb.setKey(-1);
+						cfb.setKey(0);
 						cfb.setAst(false);
 						fileNameIndices.put(path, changedFiles.size());
 						changedFiles.add(cfb);

--- a/src/test/boa/test/datagen/TestBuildSnapshot.java
+++ b/src/test/boa/test/datagen/TestBuildSnapshot.java
@@ -74,7 +74,7 @@ public class TestBuildSnapshot {
 	private static FileSystem fileSystem = null;
 	
 	private static SequenceFile.Writer projectWriter, astWriter, commitWriter, contentWriter;
-	private static long astWriterLen = 0, contentWriterLen = 0;
+	private static long astWriterLen = 1, contentWriterLen = 1;
 	
 	@Test
 	public void testGetSnapshotFromProtobuf1() throws Exception {

--- a/src/test/boa/test/datagen/java/TestJLSVersion.java
+++ b/src/test/boa/test/datagen/java/TestJLSVersion.java
@@ -71,7 +71,7 @@ public class TestJLSVersion {
 	private static FileSystem fileSystem = null;
 	
 	private static SequenceFile.Writer projectWriter, astWriter, commitWriter, contentWriter;
-	private static long astWriterLen = 0, contentWriterLen = 0;
+	private static long astWriterLen = 1, contentWriterLen = 1;
 	
 	public TestJLSVersion(String name, ChangedFile input) {
 		DefaultProperties.DEBUG = true;

--- a/src/test/boa/test/datagen/java/TestJLSVersionOfChangedFile.java
+++ b/src/test/boa/test/datagen/java/TestJLSVersionOfChangedFile.java
@@ -80,7 +80,7 @@ public class TestJLSVersionOfChangedFile {
 	private static FileSystem fileSystem = null;
 	
 	private static SequenceFile.Writer projectWriter, astWriter, commitWriter, contentWriter;
-	private static long astWriterLen = 0, contentWriterLen = 0;
+	private static long astWriterLen = 1, contentWriterLen = 1;
 	
 	public TestJLSVersionOfChangedFile(String name, ChangedFile input) {
 		DefaultProperties.DEBUG = true;


### PR DESCRIPTION
- key starting from 0 would cause duplicate keys between the last entry
of the previous repo and the first entry of the next repo
- combing needs also update the changed files in the commits that were
stored to a separate sequence file
- use 0 for keys of files that do not have data in the sequence file.
using -1 caused overflowing since keys are unsigned