### PR TITLE
Fix merge commit issue and clean datagen

### DIFF
--- a/src/java/boa/datagen/scm/AbstractCommit.java
+++ b/src/java/boa/datagen/scm/AbstractCommit.java
@@ -76,8 +76,8 @@ public abstract class AbstractCommit {
 
 	protected Map<String, Integer> fileNameIndices = new HashMap<String, Integer>();
 	protected List<ChangedFile.Builder> changedFiles = new ArrayList<ChangedFile.Builder>();
-	
-	protected ChangedFile.Builder getChangeFile(String path, ChangeKind changeKind) {
+
+	protected ChangedFile.Builder getChangedFile(String path, ChangeKind changeKind) {
 		ChangedFile.Builder cfb = null;
 		Integer index = fileNameIndices.get(path);
 		if (index == null) {
@@ -90,7 +90,7 @@ public abstract class AbstractCommit {
 			fileNameIndices.put(path, changedFiles.size());
 			changedFiles.add(cfb);
 		} else {
-			System.err.println("FIND PREVIOUS CFB!!!!!!!!!!!!");
+			System.err.println("find reduntant changed file during the update proccess");
 			cfb = changedFiles.get(index);
 		}
 		return cfb;

--- a/src/java/boa/datagen/scm/AbstractCommit.java
+++ b/src/java/boa/datagen/scm/AbstractCommit.java
@@ -33,7 +33,6 @@ import org.eclipse.php.internal.core.ast.nodes.Program;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.mozilla.javascript.CompilerEnvirons;
-import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ast.AstRoot;
 import org.w3c.css.sac.InputSource;
 
@@ -76,22 +75,24 @@ public abstract class AbstractCommit {
 	}
 
 	protected Map<String, Integer> fileNameIndices = new HashMap<String, Integer>();
-
 	protected List<ChangedFile.Builder> changedFiles = new ArrayList<ChangedFile.Builder>();
-
-	protected ChangedFile.Builder getChangeFile(String path) {
+	
+	protected ChangedFile.Builder getChangeFile(String path, ChangeKind changeKind) {
 		ChangedFile.Builder cfb = null;
 		Integer index = fileNameIndices.get(path);
 		if (index == null) {
 			cfb = ChangedFile.newBuilder();
 			cfb.setName(path);
 			cfb.setKind(FileKind.OTHER);
+			cfb.setChange(changeKind);
 			cfb.setKey(0);
 			cfb.setAst(false);
 			fileNameIndices.put(path, changedFiles.size());
 			changedFiles.add(cfb);
-		} else
+		} else {
+			System.err.println("FIND PREVIOUS CFB!!!!!!!!!!!!");
 			cfb = changedFiles.get(index);
+		}
 		return cfb;
 	}
 
@@ -208,8 +209,8 @@ public abstract class AbstractCommit {
 		else if (lowerPath.endsWith(".java")) {
 			final String content = getFileContents(path);
 			fb.setKind(FileKind.SOURCE_JAVA_ERROR);
-			parseJavaFile(path, fb, content, false);
-		} else if (lowerPath.endsWith(".js")) {
+			parseJavaFile(path, fb, content, false); // parse java file
+		} /* else if (lowerPath.endsWith(".js")) {
 			final String content = getFileContents(path);
 
 			fb.setKind(FileKind.SOURCE_JS_ES1);
@@ -305,7 +306,7 @@ public abstract class AbstractCommit {
 					System.err.println("Accepted PHP5_3: revision " + id + ": file " + path);
 			} else if (debugparse)
 				System.err.println("Accepted PHP5: revision " + id + ": file " + path);
-		}/* else if (lowerPath.endsWith(".html") && parse) {
+		} else if (lowerPath.endsWith(".html") && parse) {
 			final String content = getFileContents(path);
 
 			fb.setKind(FileKind.Source_HTML);

--- a/src/java/boa/datagen/scm/AbstractCommit.java
+++ b/src/java/boa/datagen/scm/AbstractCommit.java
@@ -33,6 +33,7 @@ import org.eclipse.php.internal.core.ast.nodes.Program;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.mozilla.javascript.CompilerEnvirons;
+import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ast.AstRoot;
 import org.w3c.css.sac.InputSource;
 
@@ -90,7 +91,7 @@ public abstract class AbstractCommit {
 			fileNameIndices.put(path, changedFiles.size());
 			changedFiles.add(cfb);
 		} else {
-			System.err.println("find reduntant changed file during the update proccess");
+			System.err.println("find redundant changed file during the update proccess");
 			cfb = changedFiles.get(index);
 		}
 		return cfb;
@@ -210,7 +211,7 @@ public abstract class AbstractCommit {
 			final String content = getFileContents(path);
 			fb.setKind(FileKind.SOURCE_JAVA_ERROR);
 			parseJavaFile(path, fb, content, false); // parse java file
-		} /* else if (lowerPath.endsWith(".js")) {
+		} else if (lowerPath.endsWith(".js")) {
 			final String content = getFileContents(path);
 
 			fb.setKind(FileKind.SOURCE_JS_ES1);
@@ -306,7 +307,7 @@ public abstract class AbstractCommit {
 					System.err.println("Accepted PHP5_3: revision " + id + ": file " + path);
 			} else if (debugparse)
 				System.err.println("Accepted PHP5: revision " + id + ": file " + path);
-		} else if (lowerPath.endsWith(".html") && parse) {
+		}/* else if (lowerPath.endsWith(".html") && parse) {
 			final String content = getFileContents(path);
 
 			fb.setKind(FileKind.Source_HTML);

--- a/src/java/boa/datagen/scm/AbstractConnector.java
+++ b/src/java/boa/datagen/scm/AbstractConnector.java
@@ -148,13 +148,14 @@ public abstract class AbstractConnector implements AutoCloseable {
 					break;
 				}
 			}
-			if (commit.parentIndices != null)
-				for (int p : commit.parentIndices) {
-					if (!queuedCommitIds.contains(p)) {
-						pq.offer(p);
-						queuedCommitIds.add(p);
-					}
+			// git system only store changed files different from the first parent commit
+			if (commit.parentIndices != null && commit.parentIndices.length != 0) {
+				int p = commit.parentIndices[0];
+				if (!queuedCommitIds.contains(p)) {
+					pq.offer(p);
+					queuedCommitIds.add(p);
 				}
+			}
 		}
 	}
 	

--- a/src/java/boa/datagen/scm/GitCommit.java
+++ b/src/java/boa/datagen/scm/GitCommit.java
@@ -186,7 +186,7 @@ public class GitCommit extends AbstractCommit {
 				while (tw.next()) {
 					if (!tw.isSubtree()) {
 						String path = tw.getPathString();
-						getChangeFile(path, ChangeKind.ADDED);
+						getChangedFile(path, ChangeKind.ADDED);
 						filePathGitObjectIds.put(path, tw.getObjectId(0));
 					}
 				}
@@ -241,7 +241,7 @@ public class GitCommit extends AbstractCommit {
 					if (diff.getOldMode().getObjectType() == Constants.OBJ_BLOB) {
 						String oldPath = diff.getOldPath();
 						String oldObjectId = diff.getOldId().toObjectId().getName();
-						ChangedFile.Builder cfb = getChangeFile(oldPath, ChangeKind.DELETED);
+						ChangedFile.Builder cfb = getChangedFile(oldPath, ChangeKind.DELETED);
 						filePathGitObjectIds.put(oldPath, diff.getNewId().toObjectId());
 					}
 				}
@@ -258,7 +258,7 @@ public class GitCommit extends AbstractCommit {
 		String newObjectId = diff.getNewId().toObjectId().getName();
 		String oldPath = diff.getOldPath();
 		String oldObjectId = diff.getOldId().toObjectId().getName();
-		ChangedFile.Builder cfb = getChangeFile(newPath, kind);
+		ChangedFile.Builder cfb = getChangedFile(newPath, kind);
 		cfb.addChanges(kind);
 		if (!oldPath.equals(newPath))
 			cfb.addPreviousNames(oldPath);

--- a/src/java/boa/functions/BoaIntrinsics.java
+++ b/src/java/boa/functions/BoaIntrinsics.java
@@ -211,9 +211,13 @@ public class BoaIntrinsics {
 				for (int i = 0; i < cf.getChangesCount(); i++) {
 //						ChangedFile pcf = revisions.get(cf.getPreviousVersions(i)).getFiles(cf.getPreviousIndices(i));
 //						String name = pcf.getName();
-					String name = cf.getPreviousNames(i);
-					if (!adds.contains(name) && !dels.contains(name))
-						dels.add(name);
+					
+					// In git system, some renamed files might not have previous names
+					if (cf.getPreviousNamesCount() != 0) {
+						String name = cf.getPreviousNames(i);
+						if (!adds.contains(name) && !dels.contains(name))
+							dels.add(name);
+					}
 				}
 				break;
 			default:
@@ -225,7 +229,9 @@ public class BoaIntrinsics {
 				break;
 			}
 		}
-		for (int p : commit.getParentsList()) {
+		// git system only consider diffs from the first parent
+		if (commit.getParentsList() != null && commit.getParentsList().size() != 0) {
+			int p = commit.getParentsList().get(0);
 			if (!queuedCommitIds.contains(p)) {
 				pq.offer(p);
 				queuedCommitIds.add(p);

--- a/src/test/boa/test/datagen/TestBuildSnapshot.java
+++ b/src/test/boa/test/datagen/TestBuildSnapshot.java
@@ -213,6 +213,18 @@ public class TestBuildSnapshot {
 			assertArrayEquals(expectedFileNames, fileNames);
 		}
 		
+		// test changed files for each commit
+		for (Revision rev : cr.getRevisionsList()) {
+			String[] expectedFileNames = conn.getDiffFiles(rev.getId()).toArray(new String[0]);
+			String[] actualFileNames = new String[rev.getFilesCount()];
+			for (int i = 0; i < actualFileNames.length; i++)
+				actualFileNames[i] = rev.getFiles(i).getName();
+			Arrays.sort(expectedFileNames);
+			Arrays.sort(actualFileNames);
+			System.out.println(rev.getId());
+			assertArrayEquals(expectedFileNames, actualFileNames);
+		}
+		
 		new Thread(new FileIO.DirectoryRemover(gitDir.getAbsolutePath())).start();
 		conn.close();
 		


### PR DESCRIPTION
1. Merge commit issue
The mechanism to store changed files in the previous version is to collect all changed files between each pair of adjacent commits.
However, a git-based software repository only stores the differences between the current commit and its first parent commit.
Three locations need to modify: 
a) AbstractConnector::getSnapshot(int commitOffset, List<ChangedFile> snapshot)
Given a revision index ordered by commit date, this method is to build a snapshot after the commit by collecting all files along with the commit history.
b) GitCommit::updateChangedFiles(RevCommit rc)
In the datagen, this method is used to collect all changed files under the given commit instance.
c) BoaIntrinsics::update
This is a helper function of a domain-specific function for collecting changed files along with the commit history.

2. Clean datagen
a) clean some code to improve reusability.
b) disable the storage of previous indices and previous versions for changed files (PS: the mechanism to extract that information should be updated latter or defined by the users' own functions)